### PR TITLE
Tolerate ITRs lacking the AAA/TTT hairpin motif

### DIFF
--- a/bin/workflow_glue/mask_itrs.py
+++ b/bin/workflow_glue/mask_itrs.py
@@ -149,9 +149,20 @@ def mask_itrs(transgene_plasmid_fasta, itr_locations):
     itr1_seq = ref[itr1_start_pos: itr1_end_pos].upper()
     itr2_seq = ref[itr2_start_pos: itr2_end_pos].upper()
 
-    # Identify parts of the ITR
-    itr1_mask_regions = [x + itr1_start_pos for x in get_variable_itr_regions(itr1_seq)]
-    itr2_mask_regions = [x + itr2_start_pos for x in get_variable_itr_regions(itr2_seq)]
+    # Identify parts of the ITR. If an ITR is incomplete or non-canonical (e.g. the
+    # intentionally truncated 5' ITR in AAVone-style all-in-one constructs) and the
+    # AAA/TTT hairpin motif can't be located, skip masking that ITR instead of crashing.
+    def safe_regions(itr_seq, start_pos, label):
+        try:
+            return [x + start_pos for x in get_variable_itr_regions(itr_seq)]
+        except ValueError as e:
+            logger.warning(
+                f"Could not find the AAA/TTT hairpin in {label}; "
+                f"leaving {label} UNMASKED. Reason: {e}")
+            return []
+
+    itr1_mask_regions = safe_regions(itr1_seq, itr1_start_pos, "ITR1")
+    itr2_mask_regions = safe_regions(itr2_seq, itr2_start_pos, "ITR2")
 
     logger.info(f'masking ITR1 variable regions: {itr1_mask_regions}')
     logger.info(f'masking ITR2 variable regions: {itr2_mask_regions}')


### PR DESCRIPTION
AAVone-style all-in-one constructs use an intentionally truncated 5' ITR that lacks the AAA hairpin loop. mask_itrs.py previously raised a fatal ValueError in this case, aborting the whole workflow at the mask_transgene_reference step.

Wrap get_variable_itr_regions() so that when the motif can't be located, the affected ITR is left unmasked (with a warning) rather than crashing. A truncated/non-isomerising ITR has no flip/flop variable region to mask, so skipping it is the correct behaviour for these constructs.